### PR TITLE
faceIds -> persistedFaceIds to match API results

### DIFF
--- a/ClientLibrary/lib/src/main/java/com/microsoft/projectoxford/face/contract/Person.java
+++ b/ClientLibrary/lib/src/main/java/com/microsoft/projectoxford/face/contract/Person.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class Person {
     public UUID personId;
 
-    public UUID[] faceIds;
+    public UUID[] persistedFaceIds;
 
     public String name;
 


### PR DESCRIPTION
Same as this issue on the iOS side: https://github.com/Microsoft/Cognitive-Face-iOS/issues/21

API seems to have changed, persisted face Ids are now returned in the `persistedFaceIds` property rather than `faceIds`