### PR TITLE
Force UTF-8 for StringEntity encoding

### DIFF
--- a/ClientLibrary/lib/build.gradle
+++ b/ClientLibrary/lib/build.gradle
@@ -26,7 +26,7 @@ group = "com.microsoft.projectoxford"
 // Artifact name is the name of the technology
 archivesBaseName = "face"
 // Update your version
-version = "1.4.1"
+version = "1.4.2"
 
 // Upload artifacts to maven central repository staging servers
 uploadArchives {

--- a/ClientLibrary/lib/src/main/java/com/microsoft/projectoxford/face/rest/WebServiceRequest.java
+++ b/ClientLibrary/lib/src/main/java/com/microsoft/projectoxford/face/rest/WebServiceRequest.java
@@ -53,6 +53,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -119,8 +120,8 @@ public class WebServiceRequest {
     private Object patch(String url, Map<String, Object> data, String contentType) throws ClientException, IOException {
         HttpPatch request = new HttpPatch(url);
         request.setHeader(HEADER_KEY, mSubscriptionKey);
-        String json = mGson.toJson(data).toString();
-        StringEntity entity = new StringEntity(json);
+        String json = mGson.toJson(data);
+        StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8.toString());
         request.setEntity(entity);
         request.setHeader(CONTENT_TYPE, APPLICATION_JSON);
         HttpResponse response = mClient.execute(request);
@@ -158,8 +159,8 @@ public class WebServiceRequest {
         request.setHeader(HEADER_KEY, this.mSubscriptionKey);
 
         if (!isStream) {
-            String json = mGson.toJson(data).toString();
-            StringEntity entity = new StringEntity(json);
+            String json = mGson.toJson(data);
+            StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8.toString());
             request.setEntity(entity);
         } else {
             request.setEntity(new ByteArrayEntity((byte[]) data.get(DATA)));
@@ -186,8 +187,8 @@ public class WebServiceRequest {
         HttpPut request = new HttpPut(url);
 
         request.setHeader(HEADER_KEY, mSubscriptionKey);
-        String json = mGson.toJson(data).toString();
-        StringEntity entity = new StringEntity(json);
+        String json = mGson.toJson(data);
+        StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8.toString());
         request.setEntity(entity);
         request.setHeader(CONTENT_TYPE, APPLICATION_JSON);
         HttpResponse response = mClient.execute(request);
@@ -217,8 +218,8 @@ public class WebServiceRequest {
             response = mClient.execute(request);
         } else {
             HttpDeleteWithBody request = new HttpDeleteWithBody(url);
-            String json = mGson.toJson(data).toString();
-            StringEntity entity = new StringEntity(json);
+            String json = mGson.toJson(data);
+            StringEntity entity = new StringEntity(json, StandardCharsets.UTF_8.toString());
             request.setEntity(entity);
             request.setHeader(CONTENT_TYPE, APPLICATION_JSON);
             request.setHeader(HEADER_KEY, mSubscriptionKey);


### PR DESCRIPTION
The default behavior is to encode as plain text w/ ISO-8859-1, so non-Latin characters are miscoded.
