### PR TITLE
Remove empty <library> tag in AndroidManifest

### DIFF
--- a/ClientLibrary/lib/src/main/AndroidManifest.xml
+++ b/ClientLibrary/lib/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="com.microsoft.projectoxford.face">
 
-    <library>
-    </library>
 
 </manifest>

--- a/Sample/gradle.properties
+++ b/Sample/gradle.properties
@@ -20,8 +20,6 @@
 // The following are used by Microsoft to upload built binaries to Maven Central Repository.
 // You can ignore them for your sample usage.
 
-android.enableAapt2=false
-
 signing.keyId=
 signing.password=
 signing.secretKeyRingFile=


### PR DESCRIPTION
The empty tag that was creating problems with Android Gradle Tools.