### PR TITLE
Upgrade Face SDK version. / Change compileSdkVersion & targetSdkVersion to 22.

### DIFF
--- a/Sample/app/build.gradle
+++ b/Sample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 22
 
     defaultConfig {
         applicationId "com.microsoft.projectoxford.faceapisample"
         minSdkVersion 22
-        targetSdkVersion 28
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }
@@ -26,10 +26,10 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     // Include local lib mostly for debug purpose.
-    //implementation project(':lib')
+    // implementation project(':lib')
 
     // Use the following line to include client library for Face API from Maven Central Repository
-    implementation 'com.microsoft.projectoxford:face:1.4.3'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.microsoft.projectoxford:face:1.4.4'
+    implementation 'com.android.support:appcompat-v7:22.1.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 }


### PR DESCRIPTION
- Upgrade Face SDK version to 1.4.4
  - Version 1.4.4 replace deprecated `HttpClient` with `OkHttp`
- Change `compileSdkVersion` & `targetSdkVersion` to 22
  - To avoid requesting related permission at the runtime in the Sample Project
  - If you still want to use a `targetSdkVersion` >= Android 6.0(API level 23), please refer to https://developer.android.com/training/permissions/requesting and add code to request for the related permission in your own project.